### PR TITLE
feat: Added a confirmation modal for widget deletion

### DIFF
--- a/src/js/common/components/Cards/WidgetCard/index.jsx
+++ b/src/js/common/components/Cards/WidgetCard/index.jsx
@@ -9,6 +9,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import More from '@material-ui/icons/MoreVert';
+import { ConfirmationModal } from 'Components/Modal';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 
@@ -17,6 +18,7 @@ import useStyles from './style';
 const WidgetCard = ({ id, onDelete, onPin, config, children, onEdit, onExport }) => {
   const classes = useStyles();
 
+  const [openModal, setOpenModal] = React.useState(false);
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
 
@@ -30,6 +32,12 @@ const WidgetCard = ({ id, onDelete, onPin, config, children, onEdit, onExport })
     setAnchorEl(null);
     callback(id);
   };
+
+  const handleConfirm = () => {
+    setOpenModal(true);
+    setAnchorEl(null);
+  };
+
   return (
     <Card className={classes.card} variant='outlined'>
       <CardHeader
@@ -62,9 +70,14 @@ const WidgetCard = ({ id, onDelete, onPin, config, children, onEdit, onExport })
               <MenuItem onClick={() => handleClose(onExport)}>
                 <ListItemText primary={t('common:export')} />
               </MenuItem>
-              <MenuItem onClick={() => handleClose(onDelete)}>
+              <MenuItem onClick={() => handleConfirm()}>
                 <ListItemText primary={t('common:delete')} />
               </MenuItem>
+              <ConfirmationModal
+                open={openModal}
+                onClose={setOpenModal}
+                callback={() => onDelete(id)}
+              />
             </Menu>
           </div>
         }

--- a/src/js/common/components/Modal/ConfirmationModal/index.jsx
+++ b/src/js/common/components/Modal/ConfirmationModal/index.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { makeStyles } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+
+const useStyles = makeStyles(theme => ({
+  deleteButton: {
+    color: theme.palette.error.main,
+  },
+  breakLine: {
+    whiteSpace: 'pre-wrap',
+  },
+}));
+
+const ConfirmationModal = ({ open, onClose, callback }) => {
+  const handleClose = () => {
+    onClose(false);
+  };
+
+  const handleCallback = () => {
+    callback();
+    onClose(false);
+  };
+
+  const classes = useStyles();
+
+  const { t } = useTranslation(['modal', 'common']);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      aria-labelledby='alert-dialog-title'
+      aria-describedby='alert-dialog-description'
+    >
+      <DialogTitle id='alert-dialog-title'>{t('modal:title')}</DialogTitle>
+      <DialogContent>
+        <DialogContentText className={classes.breakLine} id='alert-dialog-description'>
+          {t('modal:info_text')}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} color='primary'>
+          {t('common:cancel')}
+        </Button>
+        <Button onClick={handleCallback} className={classes.deleteButton} autoFocus>
+          {t('common:delete')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ConfirmationModal;
+
+ConfirmationModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  callback: PropTypes.func.isRequired,
+};

--- a/src/js/common/components/Modal/ConfirmationModal/translations/en.confirmation.modal.i18n.json
+++ b/src/js/common/components/Modal/ConfirmationModal/translations/en.confirmation.modal.i18n.json
@@ -1,0 +1,4 @@
+{
+  "title": "Do you really want to delete the widget?",
+  "info_text": "Once the widget is deleted the operation cannot be undone.\nDo you wish to continue?"
+}

--- a/src/js/common/components/Modal/ConfirmationModal/translations/pt_br.confirmation.modal.i18n.json
+++ b/src/js/common/components/Modal/ConfirmationModal/translations/pt_br.confirmation.modal.i18n.json
@@ -1,0 +1,4 @@
+{
+  "title": "Você realmente deseja remover o widget?",
+  "info_text": "Uma vez que o widget for removido a operação não pode ser desfeita.\nDeseja continuar?"
+}

--- a/src/js/common/components/Modal/index.js
+++ b/src/js/common/components/Modal/index.js
@@ -1,0 +1,1 @@
+export { default as ConfirmationModal } from './ConfirmationModal';

--- a/src/js/common/i18n/i18n.js
+++ b/src/js/common/i18n/i18n.js
@@ -1,3 +1,5 @@
+import confirmModalEN from 'Components/Modal/ConfirmationModal/translations/en.confirmation.modal.i18n.json';
+import confirmModalPtBr from 'Components/Modal/ConfirmationModal/translations/pt_br.confirmation.modal.i18n.json';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
@@ -19,6 +21,7 @@ const resources = {
     common: commonEn,
     paginator: paginatorEn,
     dashboard: dashboardEn,
+    modal: confirmModalEN,
   },
   pt: {
     login: loginPtBr,
@@ -26,11 +29,12 @@ const resources = {
     common: commonPtBr,
     paginator: paginatorPtBr,
     dashboard: dashboardPtBr,
+    modal: confirmModalPtBr,
   },
 };
 const lng = navigator.language || navigator.userLanguage;
 i18n.use(initReactI18next).init({
-  ns: ['login', 'menu', 'common', 'dashboard'],
+  ns: ['login', 'menu', 'common', 'dashboard', 'modal'],
   defaultNS: 'common',
   lng,
   resources,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Widgets are unconditionally deleted when the delete option is selected


* **What is the new behavior (if this is a feature change)?**
When the delete option is selected a modal is displayed to confirm the user action


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
dojot/dojot#2165

* **Other information**:
