### PR TITLE
Nx Fix - Device Wizard Action Buttons

### DIFF
--- a/src/js/views/createDevice/layout/ActionButtons.jsx
+++ b/src/js/views/createDevice/layout/ActionButtons.jsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { useActionButtonStyles } from './style';
 
 const ActionButtons = ({
+  isLastStep,
   withBackButton,
   isBackButtonDisabled,
   isNextButtonDisabled,
@@ -49,13 +50,14 @@ const ActionButtons = ({
         onClick={handleClickNextButton}
         disabled={isNextButtonDisabled}
       >
-        {t('next')}
+        {t(isLastStep ? 'finish' : 'next')}
       </Button>
     </Box>
   );
 };
 
 ActionButtons.propTypes = {
+  isLastStep: PropTypes.bool,
   withBackButton: PropTypes.bool,
   isBackButtonDisabled: PropTypes.bool,
   isNextButtonDisabled: PropTypes.bool,
@@ -66,6 +68,7 @@ ActionButtons.propTypes = {
 };
 
 ActionButtons.defaultProps = {
+  isLastStep: false,
   withBackButton: false,
   isBackButtonDisabled: false,
   isNextButtonDisabled: false,

--- a/src/js/views/createDevice/steps/SummaryStep/SummaryStep.jsx
+++ b/src/js/views/createDevice/steps/SummaryStep/SummaryStep.jsx
@@ -117,10 +117,11 @@ const SummaryStep = ({
       </Box>
 
       <ActionButtons
-        isNextButtonDisabled={false}
+        isNextButtonDisabled={!deviceName.trim()}
         handleClickNextButton={handleGoToNextStep}
         handleClickBackButton={handleGoToPreviousStep}
         handleClickCancelButton={handleCancelDeviceCreation}
+        isLastStep
         withBackButton
       />
     </Box>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix

* **What is the current behavior?** (You can also link to an open issue here)
The device wizard next button doesn't change it's text when is last step and isn't disabled.

* **What is the new behavior (if this is a feature change)?**
The device wizard next button change it's text to "Finish" when is the last step and get disabled if the device name input is empty. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
No

* **Other information**:
