### PR TITLE
Fix/Issue2428: Clear text fields of CSR and CA after generate certificate

### DIFF
--- a/src/js/views/createCertificate/View.jsx
+++ b/src/js/views/createCertificate/View.jsx
@@ -51,11 +51,11 @@ const CreateCertificate = () => {
     dispatch(actions.createCertificateOneClick());
   };
 
-  const handleCreateCertificateCSR = () => () => {
+  const handleCreateCertificateCSR = () => {
     dispatch(actions.createCertificateCSR({ csrPEM }));
   };
 
-  const handleRegisterExternalCertificate = () => () => {
+  const handleRegisterExternalCertificate = () => {
     dispatch(actions.registerExternalCertificate({ certificateChain }));
   };
 

--- a/src/js/views/createCertificate/View.jsx
+++ b/src/js/views/createCertificate/View.jsx
@@ -23,6 +23,8 @@ const CreateCertificate = () => {
   const certificateData = useSelector(certificateDataSelector);
 
   const [expandedCard, setExpandedCard] = useState('');
+  const [csrPEM, setCsrPEM] = useState('');
+  const [certificateChain, setCertificateChain] = useState('');
 
   useEffect(() => {
     return () => {
@@ -49,17 +51,27 @@ const CreateCertificate = () => {
     dispatch(actions.createCertificateOneClick());
   };
 
-  const handleCreateCertificateCSR = csrPEM => () => {
+  const handleCreateCertificateCSR = () => () => {
     dispatch(actions.createCertificateCSR({ csrPEM }));
   };
 
-  const handleRegisterExternalCertificate = certificateChain => () => {
+  const handleRegisterExternalCertificate = () => () => {
     dispatch(actions.registerExternalCertificate({ certificateChain }));
   };
 
   const handleClearState = () => {
     setExpandedCard('');
+    setCsrPEM('');
+    setCertificateChain('');
     dispatch(actions.getNewGeneratedCertificate({ certificateData: null }));
+  };
+
+  const handleChangeCsrPEM = e => {
+    setCsrPEM(e.target.value);
+  };
+
+  const handleChangeCertificateChain = e => {
+    setCertificateChain(e.target.value);
   };
 
   return (
@@ -79,6 +91,8 @@ const CreateCertificate = () => {
               handleToggleContent={handleToggleContent(CONSTANTS.CSR)}
               handleCreateCertificateCSR={handleCreateCertificateCSR}
               certificateData={certificateData}
+              csrPEM={csrPEM}
+              handleChangeCsrPEM={handleChangeCsrPEM}
             />
 
             <CreateCertificateCA
@@ -86,6 +100,8 @@ const CreateCertificate = () => {
               handleToggleContent={handleToggleContent(CONSTANTS.CA)}
               certificateData={certificateData}
               handleRegisterExternalCertificate={handleRegisterExternalCertificate}
+              certificateChain={certificateChain}
+              handleChangeCertificateChain={handleChangeCertificateChain}
             />
           </Box>
         </Box>

--- a/src/js/views/createCertificate/layout/CreateCertificateCA.jsx
+++ b/src/js/views/createCertificate/layout/CreateCertificateCA.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { Box, TextField, Typography, Button } from '@material-ui/core';
 import { CollapsibleList } from 'Components/CollapsibleList';
@@ -13,11 +13,11 @@ const CreateCertificateCA = ({
   handleToggleContent,
   certificateData,
   handleRegisterExternalCertificate,
+  certificateChain,
+  handleChangeCertificateChain,
 }) => {
   const classes = useStyles();
   const { t } = useTranslation('createCertificate');
-
-  const [certificateChain, setCertificateChain] = useState('');
 
   return (
     <CollapsibleList
@@ -35,7 +35,7 @@ const CreateCertificateCA = ({
 
           <TextField
             value={certificateChain}
-            onChange={e => setCertificateChain(e.target.value)}
+            onChange={handleChangeCertificateChain}
             placeholder={t('createCertificateCA.inputPlaceholder')}
             multiline
             rows={10}
@@ -45,7 +45,7 @@ const CreateCertificateCA = ({
 
           <Typography align='right'>
             <Button
-              onClick={handleRegisterExternalCertificate(certificateChain)}
+              onClick={handleRegisterExternalCertificate}
               className={classes.generateCertificateButton}
               variant='outlined'
               color='primary'
@@ -69,6 +69,8 @@ CreateCertificateCA.propTypes = {
   handleToggleContent: PropTypes.func,
   certificateData: PropTypes.object,
   handleRegisterExternalCertificate: PropTypes.func,
+  certificateChain: PropTypes.string,
+  handleChangeCertificateChain: PropTypes.func,
 };
 
 CreateCertificateCA.defaultProps = {
@@ -76,6 +78,8 @@ CreateCertificateCA.defaultProps = {
   handleToggleContent: null,
   certificateData: null,
   handleRegisterExternalCertificate: null,
+  certificateChain: '',
+  handleChangeCertificateChain: null,
 };
 
 export default CreateCertificateCA;

--- a/src/js/views/createCertificate/layout/CreateCertificateCSR.jsx
+++ b/src/js/views/createCertificate/layout/CreateCertificateCSR.jsx
@@ -13,17 +13,14 @@ const CreateCertificateCSR = ({
   isShowing,
   handleToggleContent,
   certificateData,
+  csrPEM,
+  handleChangeCsrPEM,
 }) => {
   const { t } = useTranslation('createCertificate');
   const classes = useStyles();
   const [csrHelp, setCsrHelp] = useState(false);
-  const [csrPEM, setCsrPEM] = useState('');
 
   const toggleCsrHelp = () => setCsrHelp(!csrHelp);
-
-  const handleChangeText = e => {
-    setCsrPEM(e.target.value);
-  };
 
   return (
     <CollapsibleList
@@ -57,7 +54,7 @@ const CreateCertificateCSR = ({
           </Collapse>
           <TextField
             value={csrPEM}
-            onChange={handleChangeText}
+            onChange={handleChangeCsrPEM}
             placeholder={t('createCertificateCSR.inputPlaceholder')}
             multiline
             rows={10}
@@ -66,7 +63,7 @@ const CreateCertificateCSR = ({
           />
           <Typography align='right'>
             <Button
-              onClick={handleCreateCertificateCSR(csrPEM)}
+              onClick={handleCreateCertificateCSR}
               className={classes.generateCertificateButton}
               variant='outlined'
               color='primary'
@@ -90,6 +87,8 @@ CreateCertificateCSR.propTypes = {
   isShowing: PropTypes.bool,
   handleToggleContent: PropTypes.func,
   certificateData: PropTypes.object,
+  csrPEM: PropTypes.string,
+  handleChangeCsrPEM: PropTypes.func,
 };
 
 CreateCertificateCSR.defaultProps = {
@@ -97,6 +96,8 @@ CreateCertificateCSR.defaultProps = {
   isShowing: false,
   handleToggleContent: null,
   certificateData: null,
+  csrPEM: '',
+  handleChangeCsrPEM: null,
 };
 
 export default CreateCertificateCSR;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


* **What is the current behavior?** (You can also link to an open issue here)
The texts fields of CA and CSR method of creation certificate remained with the previous text after certificate generation


* **What is the new behavior (if this is a feature change)?**
Now, after the generation of the certificate all states of the page are cleaned


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)


* **Other information**: 
dojot/dojot#2428

