### PR TITLE
NX Feature - Show the subjectDN in the certificates page

### DIFF
--- a/src/js/views/Certificates/layout/Cards.jsx
+++ b/src/js/views/Certificates/layout/Cards.jsx
@@ -46,6 +46,14 @@ const Cards = ({ certificates, handleSetCertificateOptionsMenu }) => {
                 }
               >
                 <Box marginBottom={1}>
+                  <Typography variant='body2'>{t('dataLabels.subjectDN')}</Typography>
+
+                  <Typography variant='body2'>
+                    <strong>{certificate.subjectDN}</strong>
+                  </Typography>
+                </Box>
+
+                <Box marginBottom={1}>
                   <Typography variant='body2'>{t('dataLabels.deviceId')}</Typography>
 
                   {certificate.belongsTo?.device ? (

--- a/src/js/views/Certificates/layout/DataTable.jsx
+++ b/src/js/views/Certificates/layout/DataTable.jsx
@@ -46,6 +46,10 @@ const DataTable = ({
         label: t('dataLabels.fingerprint'),
       },
       {
+        id: 'subjectDN',
+        label: t('dataLabels.subjectDN'),
+      },
+      {
         id: 'deviceId',
         label: t('dataLabels.deviceId'),
       },
@@ -197,6 +201,18 @@ const DataTable = ({
                         arrow
                       >
                         <div className={classes.truncatedText}>{certificate.fingerprint}</div>
+                      </Tooltip>
+                    </TableCell>
+
+                    <TableCell>
+                      <Tooltip
+                        title={certificate.subjectDN}
+                        classes={{ tooltip: classes.tooltip }}
+                        placement='right'
+                        interactive
+                        arrow
+                      >
+                        <div className={classes.truncatedText}>{certificate.subjectDN}</div>
                       </Tooltip>
                     </TableCell>
 

--- a/src/js/views/Certificates/translations/en.certificates.i18n.json
+++ b/src/js/views/Certificates/translations/en.certificates.i18n.json
@@ -21,6 +21,7 @@
   "validityNotDefined": "Validity Not Defined",
   "dataLabels": {
     "fingerprint": "Fingerprint",
+    "subjectDN": "Subject DN",
     "deviceId": "Device ID",
     "validity": "Validity Period",
     "status": "Status",

--- a/src/js/views/Certificates/translations/pt_br.certificates.i18n.json
+++ b/src/js/views/Certificates/translations/pt_br.certificates.i18n.json
@@ -21,6 +21,7 @@
   "validityNotDefined": "Validade Não Definida",
   "dataLabels": {
     "fingerprint": "Fingerprint",
+    "subjectDN": "Subject DN",
     "deviceId": "ID do Dispositivo",
     "validity": "Período de Validade",
     "status": "Status",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
The subjectDN is not shown in the certificates page


* **What is the new behavior (if this is a feature change)?**
The user can see the subjectDN of a certificate in the certificates page


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
dojot/dojot#2432

* **Other information**:
