### PR TITLE
Nx Fix - Improve Template Creation Clarity

### DIFF
--- a/src/js/common/components/WizardForms/TemplateCreation/TemplateCreation.jsx
+++ b/src/js/common/components/WizardForms/TemplateCreation/TemplateCreation.jsx
@@ -13,9 +13,10 @@ import {
   TableHead,
   TableRow,
   TextField,
+  Tooltip,
   Typography,
 } from '@material-ui/core';
-import { Close, Delete } from '@material-ui/icons';
+import { Close, Delete, InfoOutlined } from '@material-ui/icons';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 
@@ -99,7 +100,17 @@ const TemplateCreation = ({
               </TableCell>
 
               <TableCell>
-                <strong>{t('attrs:attrLabel.attrValue')}</strong>
+                <Tooltip
+                  classes={{ tooltip: classes.tooltip }}
+                  title={t('attrs:attrValueHint')}
+                  placement='top-start'
+                >
+                  <Box display='flex' alignItems='center'>
+                    <strong>{t('attrs:attrLabel.attrValue')}</strong>
+                    &nbsp;
+                    <InfoOutlined fontSize='small' />
+                  </Box>
+                </Tooltip>
               </TableCell>
 
               <TableCell />
@@ -108,11 +119,16 @@ const TemplateCreation = ({
 
           <TableBody>
             {attrs.map(({ id, label, type, valueType, staticValue }, index) => {
+              const isStaticAttr = type === TEMPLATE_ATTR_TYPES.STATIC.value;
+
               const handleUpdateLabel = newLabel => {
                 handleUpdateAttr(index, 'label', newLabel);
               };
 
               const handleUpdateType = newType => {
+                if (isStaticAttr && newType !== type) {
+                  handleUpdateAttr(index, 'staticValue', '');
+                }
                 handleUpdateAttr(index, 'type', newType);
               };
 
@@ -174,15 +190,16 @@ const TemplateCreation = ({
                   </TableCell>
 
                   <TableCell>
-                    <TextField
-                      className={classes.input}
-                      size='small'
-                      variant='outlined'
-                      defaultValue={staticValue}
-                      placeholder={t('attrs:attrLabel.attrValue')}
-                      disabled={type !== TEMPLATE_ATTR_TYPES.STATIC.value}
-                      onBlur={e => handleUpdateValue(e.target.value)}
-                    />
+                    {isStaticAttr && (
+                      <TextField
+                        className={classes.input}
+                        size='small'
+                        variant='outlined'
+                        defaultValue={staticValue}
+                        placeholder={t('attrs:attrLabel.attrValue')}
+                        onBlur={e => handleUpdateValue(e.target.value)}
+                      />
+                    )}
                   </TableCell>
 
                   <TableCell align='right'>

--- a/src/js/common/components/WizardForms/TemplateCreation/style.js
+++ b/src/js/common/components/WizardForms/TemplateCreation/style.js
@@ -40,4 +40,7 @@ export const useStyles = makeStyles(theme => ({
     justifyContent: 'center',
     background: theme.palette.background.default,
   },
+  tooltip: {
+    fontSize: '1rem',
+  },
 }));

--- a/src/js/common/i18n/translations/en.attrs.i18n.json
+++ b/src/js/common/i18n/translations/en.attrs.i18n.json
@@ -1,4 +1,5 @@
 {
+  "attrValueHint": "You can only set the value for static attributes.",
   "attrLabel": {
     "attrLabel": "Attribute Name",
     "attrType": "Attribute Type",

--- a/src/js/common/i18n/translations/pt_br.attrs.i18n.json
+++ b/src/js/common/i18n/translations/pt_br.attrs.i18n.json
@@ -1,4 +1,5 @@
 {
+  "attrValueHint": "Você só pode definir o valor para atributos estáticos.",
   "attrLabel": {
     "attrLabel": "Nome do Atributo",
     "attrType": "Tipo do Atributo",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


* **What is the current behavior?** (You can also link to an open issue here)
The attr value input gets disabled when the attr is not a static attr. This behavior is correct, but may cause confusion in the user


* **What is the new behavior (if this is a feature change)?**
The attr value input is hidden when the attr is not a static attr
Hovering the value header from the attrs table shows a tooltip explaining to the user that he can only set a value for static attrs


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
dojot/dojot#2438

* **Other information**:
