### PR TITLE
disable save button template if create template is loading

### DIFF
--- a/src/js/views/createTemplate/View.jsx
+++ b/src/js/views/createTemplate/View.jsx
@@ -8,7 +8,11 @@ import { useHistory } from 'react-router';
 import { AlertDialog } from '../../common/components/Dialogs';
 import { TemplateCreation } from '../../common/components/WizardForms';
 import { useTemplateCreationState } from '../../common/hooks';
-import { actions as templateActions } from '../../redux/modules/templates';
+import { useIsLoading } from '../../common/hooks/useIsLoading';
+import {
+  actions as templateActions,
+  constants as templateConstants,
+} from '../../redux/modules/templates';
 import { ViewContainer } from '../stateComponents';
 import useStyles from './style';
 
@@ -17,6 +21,8 @@ const CreateTemplate = () => {
   const dispatch = useDispatch();
   const history = useHistory();
   const classes = useStyles();
+
+  const isLoadingCreateTemplate = useIsLoading(templateConstants.CREATE_TEMPLATE);
 
   const [isShowingCancelModal, setIsShowingCancelModal] = useState(false);
 
@@ -90,7 +96,7 @@ const CreateTemplate = () => {
               type='submit'
               color='primary'
               variant='contained'
-              disabled={!canSaveTemplate}
+              disabled={!canSaveTemplate || isLoadingCreateTemplate}
             >
               {t('common:save')}
             </Button>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
improvement


* **What is the current behavior?** (You can also link to an open issue here)
The save template button on the create template screen was still enabled to execute the creation after clicking, there was no controller for loading the button


* **What is the new behavior (if this is a feature change)?**
Added a rule so that if the template creation is still loading, the button remains disabled until the loading is removed


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
dojot/dojot#2476

* **Other information**:
