### PR TITLE
Fix - Add a Text for the Default Order of Widget Filters

### DIFF
--- a/MFE/dashboard/src/view/translations/en.dashboard.i18n.json
+++ b/MFE/dashboard/src/view/translations/en.dashboard.i18n.json
@@ -66,6 +66,7 @@
     "order": "Order",
     "numberOfRecords": "Number Of Records",
     "select an option": "Select an option",
+    "orderNotDefined": "Order Not Defined",
     "last minutes": "Last minutes",
     "last hours": "Last hours",
     "last days": "Last days",

--- a/MFE/dashboard/src/view/translations/pt_br.dashboard.i18n.json
+++ b/MFE/dashboard/src/view/translations/pt_br.dashboard.i18n.json
@@ -66,6 +66,7 @@
     "order": "Ordem",
     "numberOfRecords": "Nº Registros",
     "select an option": "Selecione uma opção",
+    "orderNotDefined": "Sem Ordem Definida",
     "last minutes": "Últimos minutos",
     "last hours": "Últimas horas",
     "last days": "Últimos dias",

--- a/MFE/dashboard/src/view/widget/wizard/Steps/Filters/Filter.jsx
+++ b/MFE/dashboard/src/view/widget/wizard/Steps/Filters/Filter.jsx
@@ -98,9 +98,7 @@ const Filters = ({ validate, name, ...otherProps }) => {
                       variant='outlined'
                       disabled={otherProps.values[name].filterType !== '1'}
                     >
-                      <MenuItem value={0}>
-                        <em>&nbsp;</em>
-                      </MenuItem>
+                      <MenuItem value={0}>{t('filters.orderNotDefined')}</MenuItem>
                       <MenuItem value={1}>{t('filters.last minutes')}</MenuItem>
                       <MenuItem value={2}>{t('filters.last hours')}</MenuItem>
                       <MenuItem value={3}>{t('filters.last days')}</MenuItem>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix

* **What is the current behavior?** (You can also link to an open issue here)
Do not show a text for the order default value

* **What is the new behavior (if this is a feature change)?**
Now the item has a text

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
dojot/dojot#2593
