### PR TITLE
[DOJOT-78] Replace "widget" by "panel" in Translations

### DIFF
--- a/MFE/dashboard/src/managers/WizardManager.jsx
+++ b/MFE/dashboard/src/managers/WizardManager.jsx
@@ -34,7 +34,7 @@ const Manager = props => {
       case BAR+'':
         return t(['bar.title', 'Bar Chart']);
       case MAP+'':
-        return t(['map.title', 'Mapa']);
+        return t(['map.title', 'Map']);
       case TABLE+'':
         return t(['table.title', 'Table Chart']);
       default:

--- a/MFE/dashboard/src/view/translations/en.dashboard.i18n.json
+++ b/MFE/dashboard/src/view/translations/en.dashboard.i18n.json
@@ -2,8 +2,8 @@
   "dashboard": "Dashboard",
   "cancelDashboardCreationTitle": "Cancel Dashboard Creation",
   "cancelDashboardCreationMessage": "Are you sure you want to abandon the registration process? ALL data will be lost!",
-  "addWidget": "Add Widget",
-  "emptyMessage": "No Widget To Show",
+  "addWidget": "Add Panel",
+  "emptyMessage": "No Panel To Show",
   "steps": {
     "general": "General",
     "devices": "Devices",
@@ -11,7 +11,7 @@
     "filters": "Filters",
     "overview": "Overview"
   },
-  "widget": "Widget",
+  "widget": "Add Panel",
   "line": {
     "title": "Line Chart",
     "description": "This graph, by default, uses time as a measure of the abscissa"
@@ -79,7 +79,7 @@
     "name": "Name",
     "description": "Description",
     "nameRequired": "Name is required",
-    "enterName": "Enter the name of the widget"
+    "enterName": "Enter the name of the panel"
   },
   "summary": {
     "attributes": "Attributes"

--- a/MFE/dashboard/src/view/translations/pt_br.dashboard.i18n.json
+++ b/MFE/dashboard/src/view/translations/pt_br.dashboard.i18n.json
@@ -2,8 +2,8 @@
   "dashboard": "Dashboard",
   "cancelDashboardCreationTitle": "Cancelar Criação de Dashboard",
   "cancelDashboardCreationMessage": "Tem certeza que deseja abandonar o processo de cadastro? TODOS os dados serão perdidos!",
-  "addWidget": "Adicionar Widget",
-  "emptyMessage": "Nenhum Widget Para Exibir",
+  "addWidget": "Adicionar Painel",
+  "emptyMessage": "Nenhum Painel Para Exibir",
   "steps": {
     "general": "Geral",
     "devices": "Dispositivos",
@@ -11,7 +11,7 @@
     "filters": "Filtros",
     "overview": "Resumo"
   },
-  "widget": "Widget",
+  "widget": "Adicionar Painel",
   "line": {
     "title": "Gráfico de Linha",
     "description": "Esse gráfico, por padrão, utiliza o tempo como medida da abscissa"
@@ -80,7 +80,7 @@
     "name": "Nome",
     "description": "Descrição",
     "nameRequired": "Nome é obrigatório",
-    "enterName": "Insira o nome do widget"
+    "enterName": "Insira o nome do painel"
   },
   "summary": {
     "attributes": "Atributos"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix

* **What is the current behavior?** (You can also link to an open issue here)
Users don't understand the "widget" term that is widely used on the app

* **What is the new behavior (if this is a feature change)?**
Replace "widget" by "panel" since a dashboard can contain charts, tables and maps, not only charts.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
https://dojot.atlassian.net/browse/DOJOT-78

OBS: The widget term is still widely used in code. I didn't change that because it's not necessary. We can still use widget in code, but the user will only see "panel" on the screen.